### PR TITLE
improve reliability

### DIFF
--- a/lpc845-test-stand/test-assistant/Cargo.lock
+++ b/lpc845-test-stand/test-assistant/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cfg-if"
@@ -68,13 +68,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cortex-m"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88cdafeafba636c00c467ded7f1587210725a1adfab0c24028a7844b87738263"
+checksum = "68976165f90e3afbe181f6250fecb8da7a6d2edd3bdd21df1213cba97106a171"
 dependencies = [
  "aligned",
  "bare-metal",
  "bitfield",
+ "cortex-m 0.7.1",
+ "volatile-register",
+]
+
+[[package]]
+name = "cortex-m"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b756a8bffc56025de45218a48ff9b801180440c0ee49a722b32d49dcebc771"
+dependencies = [
+ "bare-metal",
+ "bitfield",
+ "embedded-hal 0.2.4",
  "volatile-register",
 ]
 
@@ -105,7 +118,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b30efcb6b7920d9016182c485687f0012487032a14c415d2fce6e9862ef8260e"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.6",
  "cortex-m-rt",
  "cortex-m-rtic-macros",
  "heapless",
@@ -127,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.18.2"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e86d73f2a0b407b5768d10a8c720cf5d2df49a9efc10ca09176d201ead4b7fb"
+checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
@@ -143,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm_winapi"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2265c3f8e080075d9b6417aa72293fc71662f34b4af2612d8d1b074d29510db"
+checksum = "0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9"
 dependencies = [
  "winapi",
 ]
@@ -273,9 +286,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "lock_api"
@@ -288,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -310,7 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a44c1d10aa28e2087f4032501d4d43894de0d66bc16a8c7a3a8b42ef04a4834"
 dependencies = [
  "bare-metal",
- "cortex-m",
+ "cortex-m 0.6.6",
  "cortex-m-rt",
  "vcell",
 ]
@@ -332,9 +345,9 @@ dependencies = [
 [[package]]
 name = "lpc8xx-hal"
 version = "0.8.2"
-source = "git+https://github.com/lpc-rs/lpc8xx-hal.git#85923c568c07298e3b2b17bbbe81dd13f7f7837c"
+source = "git+https://github.com/Lotterleben/lpc8xx-hal.git?branch=new_test_api#351b9c64637a1589af121380114895f548ad5c45"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.6",
  "cortex-m-rt",
  "crossterm",
  "embedded-hal 0.2.4",
@@ -461,7 +474,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcd4deccf5edead7dcd0531448f0bab1b935e6d88e47225b4b7c6bd3a443180"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.6",
  "rtt-target 0.2.2",
 ]
 
@@ -520,6 +533,7 @@ dependencies = [
 name = "protocol"
 version = "0.1.0"
 dependencies = [
+ "lpc8xx-hal",
  "serde",
 ]
 
@@ -576,7 +590,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a267556daa12832ffc20129af69a6db0a28af91bcf12b4468af21f48818f66"
 dependencies = [
- "cortex-m",
+ "cortex-m 0.6.6",
  "ufmt-write",
 ]
 
@@ -612,18 +626,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -652,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a55ca5f3b68e41c979bf8c46a6f1da892ca4db8f94023ce0bd32407573b1ac0"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -675,9 +689,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4211ce9909eb971f111059df92c45640aad50a619cf55cd76476be803c4c68e6"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/lpc845-test-stand/test-assistant/src/main.rs
+++ b/lpc845-test-stand/test-assistant/src/main.rs
@@ -901,10 +901,10 @@ const APP: () = {
 
     #[task(binds = USART0, resources = [host_rx_int])]
     fn usart0(cx: usart0::Context) {
-        cx.resources
+        // ignore serial errors from the host
+        let _ = cx.resources
             .host_rx_int
-            .receive()
-            .expect("Error receiving from USART0");
+            .receive();
     }
 
     #[task(binds = USART1, resources = [target_rx_int])]

--- a/lpc845-test-stand/test-assistant/src/main.rs
+++ b/lpc845-test-stand/test-assistant/src/main.rs
@@ -562,7 +562,7 @@ const APP: () = {
                 })
                 .expect("Error processing USART data");
 
-            host_rx
+            let _ = host_rx
                 .process_message(|message| {
                     match message {
                         HostToAssistant::SendUsart {
@@ -857,8 +857,7 @@ const APP: () = {
 
                         }
                     }
-                })
-                .expect("Error processing host request");
+                });
 
             // TODO: is pwm pin ever handled in reading messages?
             handle_pin_interrupt(pwm,   InputPin::Pwm,   &mut pins);

--- a/lpc845-test-stand/test-assistant/src/main.rs
+++ b/lpc845-test-stand/test-assistant/src/main.rs
@@ -859,7 +859,6 @@ const APP: () = {
                     }
                 })
                 .expect("Error processing host request");
-            host_rx.clear_buf();
 
             // TODO: is pwm pin ever handled in reading messages?
             handle_pin_interrupt(pwm,   InputPin::Pwm,   &mut pins);

--- a/lpc845-test-stand/test-assistant/src/main.rs
+++ b/lpc845-test-stand/test-assistant/src/main.rs
@@ -263,12 +263,12 @@ const APP: () = {
         //
         // This assumes a system clock of 12 MHz (which is the default and, as
         // of this writing, has not been changed in this program). The resulting
-        // rate is roughly 115200 baud.
+        // rate is roughly 38400 baud.
         let clock_config = {
             syscon.frg0.select_clock(frg::Clock::FRO);
             syscon.frg0.set_mult(22);
             syscon.frg0.set_div(0xFF);
-            usart::Clock::new(&syscon.frg0, 5, 16)
+            usart::Clock::new(&syscon.frg0, 17, 16)
         };
 
         // Assign pins to USART0 for RX/TX functions. On the LPC845-BRK, those

--- a/test-stand-infra/firmware-lib/src/usart.rs
+++ b/test-stand-infra/firmware-lib/src/usart.rs
@@ -70,6 +70,7 @@ impl Usart {
         let rx_idle = RxIdle {
             queue: cons,
             buf:   Vec::new(),
+            on_frame_delimiter: false,
         };
         let tx = Tx {
             usart: usart.tx,

--- a/test-stand-infra/firmware-lib/src/usart/rx.rs
+++ b/test-stand-infra/firmware-lib/src/usart/rx.rs
@@ -124,8 +124,10 @@ impl RxIdle<'_> {
                 self.on_frame_delimiter = false;
                 self.buf.clear();
             }
-            self.buf.push(b)
-                .map_err(|_| ProcessError::BufferFull)?;
+
+            // ignore buffer full error. we know this is not a valid message but wait until a frame
+            // delimiter for synchronization's sake instead of early returning an error 
+            let _ = self.buf.push(b);
 
             // Requests are COBS-encoded, so we know that `0` means we
             // received a full frame.

--- a/test-stand-infra/host-lib/src/conn.rs
+++ b/test-stand-infra/host-lib/src/conn.rs
@@ -35,6 +35,7 @@ impl Conn {
                 // this from the configuration file later.
                 &SerialPortSettings {
                     baud_rate: 38_400,
+                    timeout: Duration::from_millis(10),
                     .. SerialPortSettings::default()
                 }
             )

--- a/test-stand-infra/host-lib/src/conn.rs
+++ b/test-stand-infra/host-lib/src/conn.rs
@@ -34,7 +34,7 @@ impl Conn {
                 // The configuration is hardcoded for now. We might want to load
                 // this from the configuration file later.
                 &SerialPortSettings {
-                    baud_rate: 115200,
+                    baud_rate: 38_400,
                     .. SerialPortSettings::default()
                 }
             )

--- a/test-stand-infra/host-lib/src/pin.rs
+++ b/test-stand-infra/host-lib/src/pin.rs
@@ -5,7 +5,6 @@ use std::{
     convert::TryInto,
     fmt::Debug,
     mem::transmute,
-    thread::sleep,
     time::Duration,
 };
 
@@ -113,10 +112,6 @@ impl<Id> Pin<Id>
                 + Debug
                 + Deserialize<'de>,
     {
-        // Wait for a bit, to give whatever event is expected to change the
-        // level some time to happen.
-        sleep(timeout);
-
         let request = pin::ReadLevel {  pin: self.pin };
         let request: Request = request.into();
         conn.send(&request)


### PR DESCRIPTION
the new `blinky` test was used to test the reliability of the serial RX code on the target
sending malformed data (e.g. `echo hello > /dev/ttyACM`) between test runs was also used to verify reliability
in general, the device shouldn't panic in presence of malformed data and hardware level serial errors